### PR TITLE
update : add honcho, celery versions

### DIFF
--- a/requirement/development.txt
+++ b/requirement/development.txt
@@ -6,3 +6,4 @@ django-debug-toolbar
 django-extensions
 django-storages-redux
 boto
+honcho==0.7.1

--- a/requirement/production.txt
+++ b/requirement/production.txt
@@ -1,6 +1,6 @@
 django==1.9.7
 python-social-auth
 djangorestframework==3.4.5
-celery[redis]
+celery[redis]==3.1.23
 psycopg2==2.6.2
 django-pipeline==1.6.9


### PR DESCRIPTION
Celery[redis] > 4.0.0 dosen't support class base task any more